### PR TITLE
Fix formatting of maven repository rule

### DIFF
--- a/maven/internal/maven_repository.bzl
+++ b/maven/internal/maven_repository.bzl
@@ -320,6 +320,7 @@ def _format_maven_repository(rtx, configs, all_artifacts):
     lines.append("    deps = [")
     for coord in rtx.attr.deps:
         lines.append("        '%s'," % coord)
+    lines.append("    ],")
 
     if rtx.attr.exclude:
         lines.append("    exclude = {")


### PR DESCRIPTION
This fixes the output when `transitive_deps` is not set.