### PR TITLE
upgrade to latest gradle

### DIFF
--- a/maven/internal/maven_repositories.bzl
+++ b/maven/internal/maven_repositories.bzl
@@ -1,7 +1,7 @@
 load("//maven:internal/require.bzl", "require")
 load("//maven:internal/require_toolchain.bzl", "require_toolchain")
 
-GRADLE_VERSION = "4.1"
+GRADLE_VERSION = "4.10.2"
 
 GRADLE_BUILD_FILE = """
 java_import(

--- a/maven/internal/maven_repository.bzl
+++ b/maven/internal/maven_repository.bzl
@@ -592,7 +592,7 @@ maven_repository = repository_rule(
             cfg = "host",
         ),
         "_gradle_launcher_jar": attr.label(
-            default = Label("@gradle_distribution//:lib/gradle-launcher-4.1.jar"),
+            default = Label("@gradle_distribution//:lib/gradle-launcher-4.10.2.jar"),
             executable = True,
             cfg = "host",
         ),


### PR DESCRIPTION
Newer java versions seem to make gradle 4.1 barf:

    FAILURE: Build failed with an exception.

    * What went wrong:
    Could not determine java version from '11'.

Upgrading to latest gradle fixes it for me...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pubref/rules_maven/18)
<!-- Reviewable:end -->
