### PR TITLE
maven/rules.bzl: expose rules

### DIFF
--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -1,3 +1,7 @@
-load("//maven:internal/maven_repositories.bzl", "maven_repositories")
-load("//maven:internal/maven_repository.bzl", "maven_repository")
-load("//maven:internal/require.bzl", "require")
+load("//maven:internal/maven_repositories.bzl", _maven_repositories = "maven_repositories")
+load("//maven:internal/maven_repository.bzl", _maven_repository = "maven_repository")
+load("//maven:internal/require.bzl", _require = "require")
+
+maven_repositories = _maven_repositories
+maven_repository = _maven_repository
+require = _require


### PR DESCRIPTION
This will be required in bazel 0.25.0, which flips the flag `--incompatible_no_transitive_loads` to `true`. 

Following the suggestion [here](https://github.com/bazelbuild/bazel/issues/5636#issue-342700540), we explicitly alias and then re-export the three rules we want to make visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pubref/rules_maven/24)
<!-- Reviewable:end -->
